### PR TITLE
feat: nodemailer setup

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -24,3 +24,9 @@ JWT_SECRET=secret
 # Ejemplo formato: 60, "2 days", "10h", "7d"
 # Unidad por defecto es milisegundos (60 = 60ms)
 JWT_EXPIRES_IN=1d
+
+# Configuración Nodemailer
+MAIL_HOST=smtp.gmail.com
+MAIL_PORT=587
+MAIL_USER=adlempleabilidad@gmail.com
+MAIL_PASSWORD=

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "dotenv": "^16.4.5",
         "express": "^4.19.1",
         "jsonwebtoken": "^9.0.2",
+        "nodemailer": "^6.9.13",
         "pg": "^8.11.5",
         "pg-hstore": "^2.3.4",
         "sequelize": "^6.37.1",
@@ -3756,6 +3757,14 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.9.13",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.13.tgz",
+      "integrity": "sha512-7o38Yogx6krdoBf3jCAqnIN4oSQFx+fMa0I7dK1D+me9kBxx12D+/33wSb+fhOCtIxvYJ+4x4IMEhmhCKfAiOA==",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "dotenv": "^16.4.5",
     "express": "^4.19.1",
     "jsonwebtoken": "^9.0.2",
+    "nodemailer": "^6.9.13",
     "pg": "^8.11.5",
     "pg-hstore": "^2.3.4",
     "sequelize": "^6.37.1",

--- a/src/config/mail.js
+++ b/src/config/mail.js
@@ -1,0 +1,20 @@
+import nodemailer from 'nodemailer';
+
+const transporter = nodemailer.createTransport({
+  host: process.env.MAIL_HOST,
+  port: process.env.MAIL_PORT,
+  auth: {
+    user: process.env.MAIL_USER,
+    pass: process.env.MAIL_PASSWORD
+  }
+})
+
+transporter.verify(function (error, success) {
+  if (error) {
+    console.log(error);
+  } else {
+    console.log("Servidor de correo listo para recibir nuestros mensajes");
+  }
+});
+
+export default transporter;

--- a/src/controllers/usuariosController.js
+++ b/src/controllers/usuariosController.js
@@ -1,4 +1,5 @@
 import { Usuarios } from "../models/Usuarios.js";
+import transporter from "../config/mail.js";
 
 // Include
 import { Metas } from "../models/Metas.js";
@@ -23,6 +24,26 @@ export async function getUsuarios(req, res) {
 export async function postUsuarios(req, res) {
   try {
     const nuevoUsuario = await Usuarios.create(req.body);
+
+    const correo_activacion = {
+      from: `ADL Empleabilidad <${process.env.MAIL_USER}>`,
+      to: nuevoUsuario.correo_electronico,
+      subject: '¡Bienvenido a ADL Empleabilidad! Activa tu cuenta',
+      text: 'Accede a este link para activar tu cuenta: URL aquí',
+      html: `
+      <h1>¡Bienvenido a ADL Empleabilidad!</h1>
+      <p>Puedes activar tu cuenta haciendo clic en este link: <a href='#'>Activa tu cuenta</a></p>
+      `
+    }
+
+    transporter.sendMail(correo_activacion, (err, info) => {
+      if (err) {
+        console.error(err);
+        return;
+      }
+      console.log("Correo de activación enviado con éxito. ID Correo: %s", info.messageId);
+    })
+
     res.status(201).json(nuevoUsuario);
   } catch (error) {
     res.status(400).json({ message: error.message });


### PR DESCRIPTION
# Implementación de Nodemailer

## Descripción
Se configura nodemailer y se agrega correo de activación (sin URL) a creación de usuario.

## Capturas de pantalla (si es aplicable)
![image](https://github.com/dlab-team/c18-backend/assets/39388875/125f4ebf-cb2a-43cb-a819-fec10a8282da)

## Cambios probados
Se creó un usuario con correo `user@example.com` y se utilizó [Mailtrap](https://mailtrap.io/) para capturar y analizar el correo de activación generado por la aplicación.

## Tareas pendientes
- Agregar link a endpoint de activación de cuenta.
- Crear templates con estilos para los correos.

## Comprobaciones previas a la fusión
- [ ] Los cambios introducidos pasan todas las pruebas.
- [ ] Se ha revisado y se han resuelto los comentarios de los revisores.
- [ ] Se han actualizado los documentos relevantes si es necesario.
- [ ] La rama de esta solicitud de extracción se puede fusionar de manera segura.

