### PR TITLE
fix: server error on missing token

### DIFF
--- a/src/controllers/autenticacionController.js
+++ b/src/controllers/autenticacionController.js
@@ -34,7 +34,7 @@ export async function login(req, res) {
 
 export async function activar(req, res) {
   try {
-    const usuario = await Usuarios.findByPk(req.usuario.id);
+    const usuario = await Usuarios.findByPk(req.payload.sub);
     if (usuario.rol === "inactivo") {
       usuario.rol = "user";
       await usuario.save();

--- a/src/controllers/passwordController.js
+++ b/src/controllers/passwordController.js
@@ -53,21 +53,12 @@ export async function solicitarResetContrasena(req, res) {
 export async function resetearContrasena(req, res) {
   try {
     const { nuevaContrasena } = req.body;
-    const token = req.headers.authorization.split(" ")[1];
-    // formato token: 'Authorization: Bearer header.payload.signature'
 
-    let payload;
-    try {
-      payload = jwt.verify(token, process.env.JWT_SECRET);
-    } catch (error) {
-      return res.status(400).json({ message: "Token inválido o expirado" });
-    }
-
-    if (!payload.reset_pass) {
+    if (!req.payload.reset_pass) {
       return res.status(400).json({ message: "Token inválido" });
     }
 
-    const usuario = await Usuarios.findByPk(payload.sub);
+    const usuario = await Usuarios.findByPk(req.payload.sub);
     if (!usuario) {
       return res.status(404).json({ message: "Usuario no encontrado" });
     }

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -15,7 +15,7 @@ async function verificarToken(token) {
       return false;
     }
 
-    return tokenVerificado.sub;
+    return tokenVerificado;
   } catch (error) {
     return false;
   }
@@ -23,11 +23,11 @@ async function verificarToken(token) {
 
 export async function requiereAuth(req, res, next) {
   try {
-    const token = req.headers.authorization.split(" ")[1];
+    const token = req.headers.authorization;
     if (token) {
-      const tokenVerificado = await verificarToken(token);
+      const tokenVerificado = await verificarToken(token.split(" ")[1]);
       if (tokenVerificado) {
-        req.usuario = await Usuarios.findByPk(tokenVerificado);
+        req.payload = tokenVerificado;
         next();
       } else {
         res.status(401).json({ error: "Token inválido" });
@@ -54,7 +54,7 @@ export function invalidarToken(req, res, next) {
 export function rolAccess(opciones = { roles: ["admin", "user", "inactivo"] }) {
   return async (req, res, next) => {
     try {
-      const usuario = await Usuarios.findByPk(req.usuario.id, {
+      const usuario = await Usuarios.findByPk(req.payload.sub, {
         attributes: ["id", "rol"],
       });
       if (opciones.roles.includes(usuario.rol)) {

--- a/src/routes/password.routes.js
+++ b/src/routes/password.routes.js
@@ -3,10 +3,11 @@ import {
   solicitarResetContrasena,
   resetearContrasena,
 } from "../controllers/passwordController.js";
+import { requiereAuth } from "../middleware/auth.js";
 
 const router = Router();
 
 router.post("/recuperar-contrasena", solicitarResetContrasena);
-router.post("/resetear-contrasena", resetearContrasena);
+router.post("/resetear-contrasena", requiereAuth, resetearContrasena);
 
 export default router;


### PR DESCRIPTION
# Fix a error en el servidor cuando se recibe un request sin JWT.
Además, se refactorizó código relacionado a reset de contraseña y al middleware encargado de verificar los JWT.

## Problema
Al enviar un request a una ruta protegida sin JWT se generaba un error en el servidor debido a que intentaba ejecutar ciertas funciones en un valor indefinido:
```js
// req.headers.authorization == undefined
const token = req.headers.authorization.split(" ")[1];
// TypeError: Cannot read properties of undefined

```

## Solución propuesta
Chequear si `req.headers.authorization` existe antes de ejecutar el middleware que administra los JWT.

## Cambios probados
cURL a rutas protegidas sin JWT ahora produce error 401 en vez de 500.

## Comentarios adicionales
Además se refactorizó el middleware para que agregue el payload completo del JWT al request y se eliminó la lógica relacionada a verificar el token del endpoint de reset de contraseña. Ahora este endpoint utiliza el middleware para verificar el JWT y solo se encarga de analizar su contenido y ejecutar las acciones correspondientes.

## Comprobaciones previas a la fusión
- [ ] Los cambios introducidos pasan todas las pruebas.
- [ ] Se ha revisado y se han resuelto los comentarios de los revisores.
- [ ] Se han actualizado los documentos relevantes si es necesario.
- [ ] La rama de esta solicitud de extracción se puede fusionar de manera segura.

